### PR TITLE
feat: Add `onError` handle

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 ![Build & Deploy][build-badge] [![Total alerts][lgtm-badge]][lgtm-alerts]
 [![LGTM Grade][lgtm-grade]][lgtm-alerts]
 [![Maintainability][codeclimate-badge]][codeclimate]
-[![npm bundle size][bundle-size]][npm]
 
 ![PubSub HTTP Handler](.github/header.jpg)
 
@@ -64,7 +63,7 @@ documentation][docs]
 ## Contributing
 
 We love contributions! 🙏 Bug reports and pull requests are welcome on
-[GitHub][github].
+[GitHub].
 
 [banner]: ./assets/banner.jpg
 [npm]: https://www.npmjs.com/package/pubsub-http-handler
@@ -79,10 +78,9 @@ We love contributions! 🙏 Bug reports and pull requests are welcome on
 [lgtm-alerts]: https://lgtm.com/projects/g/cobraz/pubsub-http-handler/alerts/
 [lgtm-grade]:
   https://img.shields.io/lgtm/grade/javascript/github/cobraz/pubsub-http-handler?style=flat-square
-[bundle-size]:
-  https://img.shields.io/bundlephobia/min/@cobraz/pubsub-http-handler?style=flat-square
 [semantic-release-badge]:
   https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg?style=flat-square
 [fastify]: https://www.fastify.io/
 [configuration]: ./docs/interfaces/pubsubconfig.md
 [docs]: ./docs/
+[github]: https://github.com/cobraz/pubsub-http-handler/issues

--- a/README.md
+++ b/README.md
@@ -54,11 +54,12 @@ documentation][docs]
 
 ## Options
 
-- `onError` (function). Used to ensure that the function does not throw.
-  **Note:** When applied, the function will return 204 regardless.
+- `onError` (function, default is undefined). Used to ensure that the function
+  does not throw. **Note:** When applied, the function will return `204`
+  regardless.
 
-- `parseJson` (default is `true`). When set to true, uses `JSON.parse` to parse
-  the data sent through PubSub.
+- `parseJson` (boolean, default is `true`). When set to true, uses `JSON.parse`
+  to parse the data sent through PubSub.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,14 @@ documentation][docs]
 
 [examples]: ./examples
 
+## Options
+
+- `onError` (function). Used to ensure that the function does not throw.
+  **Note:** When applied, the function will return 200 regardless.
+
+- `parseJson` (default is `true`). When set to true, uses `JSON.parse` to parse
+  the data sent through PubSub.
+
 ## Contributing
 
 We love contributions! 🙏 Bug reports and pull requests are welcome on

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ documentation][docs]
 ## Options
 
 - `onError` (function). Used to ensure that the function does not throw.
-  **Note:** When applied, the function will return 200 regardless.
+  **Note:** When applied, the function will return 204 regardless.
 
 - `parseJson` (default is `true`). When set to true, uses `JSON.parse` to parse
   the data sent through PubSub.

--- a/src/__tests__/cloud-functions.test.ts
+++ b/src/__tests__/cloud-functions.test.ts
@@ -20,4 +20,33 @@ describe('cloud functions', () => {
       context: JSON.parse(JSON.stringify(payload)),
     });
   });
+  it('should return onError on throw', async () => {
+    const payload = createPubSubRequest('forward me');
+    const handle = () => {
+      throw new Error('error');
+    };
+    const onError = jest.fn();
+    const send = jest.fn();
+    const fun = await createPubSubCloudFunctions(handle, { onError });
+    await fun(
+      { body: payload } as any,
+      ({ status: () => ({ send }) } as unknown) as any,
+    );
+
+    expect(onError).toHaveBeenCalledWith(new Error('error'));
+  });
+
+  it('should not return onError on throw', async () => {
+    const payload = createPubSubRequest('forward me');
+    const handle = () => {
+      throw new Error('error');
+    };
+    const send = jest.fn();
+    const fun = await createPubSubCloudFunctions(handle);
+
+    await fun(
+      { body: payload } as any,
+      ({ status: () => ({ send }) } as unknown) as any,
+    ).catch(e => expect(e).toEqual('error'));
+  });
 });

--- a/src/__tests__/fastify-plugin.test.ts
+++ b/src/__tests__/fastify-plugin.test.ts
@@ -52,4 +52,41 @@ describe('fastify-plugin', () => {
       context: JSON.parse(JSON.stringify(payload)),
     });
   });
+
+  it('should return onError on throw', async () => {
+    const handler = () => {
+      throw new Error('error');
+    };
+    const onError = jest.fn();
+    const payload = createPubSubRequest('forward me');
+
+    app.register(pubSubFastifyPlugin, { handler, onError });
+
+    await app.inject({
+      method: 'POST',
+      url: '/',
+      payload,
+    });
+
+    expect(onError).toHaveBeenCalledWith(new Error('error'));
+  });
+
+  it('should not return onError on throw', async () => {
+    const handler = () => {
+      throw new Error('error');
+    };
+    const payload = createPubSubRequest('forward me');
+
+    app.register(pubSubFastifyPlugin, { handler });
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/',
+      payload,
+    });
+
+    expect(res.payload).toMatchInlineSnapshot(
+      `"{\\"statusCode\\":500,\\"error\\":\\"Internal Server Error\\",\\"message\\":\\"error\\"}"`,
+    );
+  });
 });

--- a/src/methods/cloud-functions.ts
+++ b/src/methods/cloud-functions.ts
@@ -13,14 +13,19 @@ export function createPubSubCloudFunctions<T = unknown>(
   handler: PubSubHandler<T>,
   options: PubSubCloudFunctionsConfig = {},
 ): CloudFunctionFun {
-  const { parseJson } = options;
+  const { parseJson, onError } = options;
   return async (req, res): Promise<void> => {
     await handlePubSubMessage({
       message: req.body.message,
       handler,
       context: req.body,
       parseJson,
+    }).catch(error => {
+      if (onError) {
+        return onError(error);
+      }
     });
+
     res.status(200).send();
   };
 }

--- a/src/methods/server.ts
+++ b/src/methods/server.ts
@@ -33,13 +33,14 @@ export function createPubSubServer<T = unknown>(
     address = '0.0.0.0',
     parseJson = true,
     path = '/',
+    onError,
   } = config;
 
   const fastify = Fastify({
     ...fastifyConfig,
   });
 
-  fastify.register(pubSubFastifyPlugin, { handler, parseJson, path });
+  fastify.register(pubSubFastifyPlugin, { handler, parseJson, path, onError });
 
   return {
     async listen() {

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,6 +6,15 @@ export interface PubSubConfig {
    */
   handler: PubSubHandler;
   /**
+   * OnError Handler
+   *
+   * When this is set, errors will not be
+   * thrown.
+   */
+  onError?: OnErrorHandler;
+  /**
+   * This will run JSON.parse on request data
+   *
    * **Tip**: `false` when sending strings
    * @default true
    */
@@ -41,3 +50,5 @@ export type PubSubHandler<T = any> = (args: {
   data?: T;
   context?: unknown;
 }) => Promise<PubSubHandlerResponse | void> | PubSubHandlerResponse | void;
+
+export type OnErrorHandler = (error: unknown) => Promise<void>;


### PR DESCRIPTION
This pull request adds a new `onError` handle, which also makes the function not throw and always return 204.