### PR TITLE
fix: change engine to node@14.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   "devDependencies": {
     "@tsconfig/node14": "^1.0.1",
     "@types/jest": "^26.0.15",
+    "@types/json-schema-faker": "^0.5.1",
     "@types/node": "^14.14.16",
     "@typescript-eslint/eslint-plugin": "4.8.2",
     "@typescript-eslint/parser": "4.8.2",

--- a/package.json
+++ b/package.json
@@ -5,12 +5,12 @@
   "repository": "github:cobraz/pubsub-http-handler",
   "license": "Apache-2.0",
   "author": "Simen A. W. Olsen <cobraz@cobraz.no>",
-  "main": "dist/src/index.js",
+  "main": "dist/index.js",
   "engines": {
     "node": ">=14.15"
   },
   "files": [
-    "dist/src"
+    "dist"
   ],
   "scripts": {
     "build": "tsc",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   "license": "Apache-2.0",
   "author": "Simen A. W. Olsen <cobraz@cobraz.no>",
   "main": "dist/src/index.js",
+  "engines": {
+    "node": ">=14.15"
+  },
   "files": [
     "dist/src"
   ],
@@ -26,12 +29,13 @@
     ]
   },
   "dependencies": {
-    "@types/express": "^4.17.13",
     "@sinclair/typebox": "^0.12.7",
+    "@types/express": "^4.17.13",
     "fastify": "^3.9.2",
     "fastify-plugin": "^3.0.0"
   },
   "devDependencies": {
+    "@tsconfig/node14": "^1.0.1",
     "@types/jest": "^26.0.15",
     "@types/node": "^14.14.16",
     "@typescript-eslint/eslint-plugin": "4.8.2",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,10 @@
 {
   "extends": "@tsconfig/node14/tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "declaration": true,
+    "sourceMap": true
+  },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "**/*.spec.ts"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,18 +1,5 @@
 {
-  "compilerOptions": {
-    "module": "commonjs",
-    "declaration": true,
-    "noImplicitAny": false,
-    "importHelpers": true,
-    "removeComments": true,
-    "noLib": false,
-    "emitDecoratorMetadata": true,
-    "experimentalDecorators": true,
-    "target": "es6",
-    "sourceMap": false,
-    "outDir": "./dist",
-    "skipLibCheck": true
-  },
-  "include": ["src/**/*", "examples/**/*"],
+  "extends": "@tsconfig/node14/tsconfig.json",
+  "include": ["src/**/*"],
   "exclude": ["node_modules", "**/*.spec.ts"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -627,6 +627,18 @@
     jest-diff "^26.0.0"
     pretty-format "^26.0.0"
 
+"@types/json-schema-faker@^0.5.1":
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/@types/json-schema-faker/-/json-schema-faker-0.5.1.tgz#6558d9704ab8b08c982846a7bdb73a41576ae8e1"
+  integrity sha512-gXkZKNeQEMLFH2aYVG+ZSxdrLN2MCi0V6CoB3RAcUSz1BTfXntCOpTDdrfx+rTQ3x2sctFjM3gGauqDVxDXI7g==
+  dependencies:
+    "@types/json-schema" "*"
+
+"@types/json-schema@*":
+  version "7.0.9"
+  resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.9.tgz#97edc9037ea0c38585320b28964dde3b39e4660d"
+  integrity sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==
+
 "@types/json-schema@^7.0.3":
   version "7.0.6"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.6.tgz#f4c7ec43e81b319a9815115031709f26987891f0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -521,6 +521,11 @@
   dependencies:
     "@sinonjs/commons" "^1.7.0"
 
+"@tsconfig/node14@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node14/-/node14-1.0.1.tgz#95f2d167ffb9b8d2068b0b235302fafd4df711f2"
+  integrity sha512-509r2+yARFfHHE7T6Puu2jjkoycftovhXRqW328PDXTVGKihlb1P8Z9mMZH04ebyajfRY7dedfGynlrFHJUQCg==
+
 "@types/babel__core@^7.0.0", "@types/babel__core@^7.1.7":
   version "7.1.12"
   resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.1.12.tgz#4d8e9e51eb265552a7e4f1ff2219ab6133bdfb2d"


### PR DESCRIPTION
Removes experimentalDecorators and `tslib` dependency.
