### PR TITLE
fix: `attributes` should not be required

### DIFF
--- a/src/__tests__/fastify-plugin.test.ts
+++ b/src/__tests__/fastify-plugin.test.ts
@@ -89,4 +89,25 @@ describe('fastify-plugin', () => {
       `"{\\"statusCode\\":500,\\"error\\":\\"Internal Server Error\\",\\"message\\":\\"error\\"}"`,
     );
   });
+
+  it('should not throw if request is missing attributes', async () => {
+    const handler = jest.fn();
+    const payload = {
+      message: {
+        data: 'ImZvcndhcmQgbWUi',
+        messageId: 'in dolor Ut',
+      },
+      subscription: 'mollit sint',
+    };
+
+    app.register(pubSubFastifyPlugin, { handler });
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/',
+      payload,
+    });
+
+    expect(res.statusCode).toBe(204);
+  });
 });

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -14,6 +14,7 @@ describe('index', () => {
                 "type": "string",
               },
               "kind": Symbol(DictKind),
+              "modifier": Symbol(OptionalModifier),
               "type": "object",
             },
             "data": Object {
@@ -27,7 +28,6 @@ describe('index', () => {
             },
           },
           "required": Array [
-            "attributes",
             "data",
           ],
           "type": "object",
@@ -44,6 +44,7 @@ describe('index', () => {
                     "type": "string",
                   },
                   "kind": Symbol(DictKind),
+                  "modifier": Symbol(OptionalModifier),
                   "type": "object",
                 },
                 "data": Object {
@@ -57,7 +58,6 @@ describe('index', () => {
                 },
               },
               "required": Array [
-                "attributes",
                 "data",
               ],
               "type": "object",

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,7 +27,7 @@ export interface PubSubConfig {
 }
 
 export const PubSubMessage = Type.Object({
-  attributes: Type.Dict(Type.String()),
+  attributes: Type.Optional(Type.Dict(Type.String())),
   data: Type.String(),
   messageId: Type.Optional(Type.String()),
 });


### PR DESCRIPTION
Attributes are not required, so it shouldn't fail if it's not set. Also adds a test to ensure this.
