### PR TITLE
feat: add eagerAck config

### DIFF
--- a/src/__tests__/fastify-plugin.test.ts
+++ b/src/__tests__/fastify-plugin.test.ts
@@ -110,4 +110,30 @@ describe('fastify-plugin', () => {
 
     expect(res.statusCode).toBe(204);
   });
+
+  it.only('should support immediate ack', async () => {
+    let shouldFinish = false;
+    let handlerFinished = false;
+
+    app.register(pubSubFastifyPlugin, {
+      handler: async () => {
+        while (!shouldFinish) {
+          await new Promise(res => setTimeout(res, 50));
+        }
+        handlerFinished = true;
+      },
+
+      alwaysAck: true,
+    });
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/',
+      payload: createPubSubRequest('boops'),
+    });
+
+    expect(res.statusCode).toBe(204);
+    expect(handlerFinished).toEqual(false);
+    shouldFinish = true;
+  });
 });

--- a/src/types.ts
+++ b/src/types.ts
@@ -24,6 +24,12 @@ export interface PubSubConfig {
    * @default /
    */
   path?: string;
+  /**
+   * If true, always ack the pubsub message,
+   * regardless if the handler succeeds or not.
+   * @default false
+   */
+  alwaysAck?: boolean;
 }
 
 export const PubSubMessage = Type.Object({


### PR DESCRIPTION
See #49

Probably a nicer way to do the test?

The point is to make sure we always ack, no matter if the handler succeeds or fails.