### PR TITLE
feat: always provide `context` argument

### DIFF
--- a/src/__tests__/cloud-functions.test.ts
+++ b/src/__tests__/cloud-functions.test.ts
@@ -30,7 +30,7 @@ describe('cloud functions', () => {
       { status: () => ({ send }) } as unknown as any,
     );
 
-    expect(onError).toHaveBeenCalledWith(new Error('error'));
+    expect(onError).toHaveBeenCalledWith(new Error('error'), payload);
   });
 
   it('should throw when onError is undefined', async () => {

--- a/src/__tests__/common.test.ts
+++ b/src/__tests__/common.test.ts
@@ -23,11 +23,13 @@ describe('common', () => {
       message,
       handler,
       parseJson: false,
+      context: {},
       log: {} as pino.Logger,
     });
     expect(handler).toHaveBeenCalledWith({
       message,
       data: 'hello-world',
+      context: {},
       log: {},
     });
   });
@@ -39,11 +41,13 @@ describe('common', () => {
       message,
       handler,
       parseJson: true,
+      context: {},
       log: {} as pino.Logger,
     });
     expect(handler).toHaveBeenCalledWith({
       message,
       data: { name: 'Simen' },
+      context: {},
       log: {},
     });
   });
@@ -75,12 +79,14 @@ describe('common', () => {
       message,
       handler,
       parser: data => parser(data),
+      context: {},
       log: {} as pino.Logger,
     });
 
     expect(handler).toHaveBeenCalledWith({
       message,
       data: '',
+      context: {},
       log: {} as pino.Logger,
     });
 
@@ -99,10 +105,11 @@ describe('common', () => {
         message,
         handler,
         parser: data => parser(data),
+        context: {},
         log: {} as pino.Logger,
       });
     };
 
-    expect(result).rejects.toThrowErrorMatchingInlineSnapshot(`"error"`);
+    await expect(result).rejects.toThrowErrorMatchingInlineSnapshot(`"error"`);
   });
 });

--- a/src/__tests__/fastify-plugin.test.ts
+++ b/src/__tests__/fastify-plugin.test.ts
@@ -73,7 +73,10 @@ describe('fastify-plugin', () => {
       payload,
     });
 
-    expect(onError).toHaveBeenCalledWith(new Error('error'));
+    expect(onError).toHaveBeenCalledWith(
+      new Error('error'),
+      expect.objectContaining({ body: payload }),
+    );
   });
 
   it('should not return onError on throw', async () => {

--- a/src/methods/cloud-functions.ts
+++ b/src/methods/cloud-functions.ts
@@ -20,11 +20,12 @@ export function createPubSubCloudFunctions<Data = unknown, Context = unknown>(
 ): CloudFunctionFun {
   const { parseJson, onError, logger } = options;
   return async (req, res): Promise<void> => {
+    const context: Context = req.body;
     try {
       await handlePubSubMessage({
         message: req.body.message,
         handler,
-        context: req.body,
+        context,
         parseJson,
         log: pino(gcpLogOptions(logger)),
       });
@@ -32,9 +33,11 @@ export function createPubSubCloudFunctions<Data = unknown, Context = unknown>(
       res.status(200).send();
     } catch (error) {
       if (onError) {
-        await onError(error);
+        await onError(error, context);
         res.status(200).send();
-      } else throw error;
+      } else {
+        throw error;
+      }
     }
   };
 }

--- a/src/methods/server.ts
+++ b/src/methods/server.ts
@@ -1,4 +1,8 @@
-import Fastify, { FastifyInstance, FastifyServerOptions } from 'fastify';
+import Fastify, {
+  FastifyInstance,
+  FastifyRequest,
+  FastifyServerOptions,
+} from 'fastify';
 import { PubSubConfig, PubSubHandler } from '../types';
 import { pubSubFastifyPlugin } from './fastify-plugin';
 
@@ -32,9 +36,9 @@ export interface CreatePubSubHandlerResponse {
   fastify: FastifyInstance;
 }
 
-export function createPubSubServer<Data, Context>(
-  handler: PubSubHandler<Data, Context>,
-  config: PubSubServerConfig<Data, Context> = {},
+export function createPubSubServer<Data>(
+  handler: PubSubHandler<Data, FastifyRequest>,
+  config: PubSubServerConfig<Data, FastifyRequest> = {},
 ): CreatePubSubHandlerResponse {
   let { host = '0.0.0.0' } = config;
   const {

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,7 +13,7 @@ export interface PubSubConfig<Data, Context> {
    * When this is set, errors will not be
    * thrown.
    */
-  onError?: OnErrorHandler;
+  onError?: OnErrorHandler<Context>;
 
   parser?: (data: unknown) => Data | Promise<Data>;
   /**
@@ -57,13 +57,16 @@ export type PubSubHandler<Data, Context> = (args: {
   log: FastifyLoggerInstance;
 }) => Promise<PubSubHandlerResponse | void> | PubSubHandlerResponse | void;
 
-export type OnErrorHandler = (error: unknown) => void | Promise<void>;
+export type OnErrorHandler<Context> = (
+  error: unknown,
+  context: Context,
+) => void | Promise<void>;
 
 export interface HandlePubSubMessageArgs<Data, Context> {
   message: PubSubMessageType;
   handler: PubSubHandler<Data, Context>;
   parseJson?: boolean;
   parser?: (data: unknown) => Data | Promise<Data>;
-  context?: Context;
+  context: Context;
   log?: pino.Logger | FastifyBaseLogger;
 }


### PR DESCRIPTION
I need access to the `request` object inside our message handler.