### PR TITLE
feat: Replaced type usage

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -34,13 +34,15 @@ pubsub-http-handler
 - [createPubSubCloudFunctions](README.md#createpubsubcloudfunctions)
 - [createPubSubServer](README.md#createpubsubserver)
 - [handlePubSubMessage](README.md#handlepubsubmessage)
+- [makePubSubConfig](README.md#makepubsubconfig)
 - [pubSubFastifyPlugin](README.md#pubsubfastifyplugin)
 
 ## Type Aliases
 
 ### CloudFunctionFun
 
-Ƭ **CloudFunctionFun**: (`req`: `express.Request`, `res`: `express.Response`) => `Promise`<`void`\>
+Ƭ **CloudFunctionFun**: (`req`: `express.Request`, `res`: `express.Response`) =>
+`Promise`<`void`\>
 
 #### Type declaration
 
@@ -48,9 +50,9 @@ pubsub-http-handler
 
 ##### Parameters
 
-| Name | Type |
-| :------ | :------ |
-| `req` | `express.Request` |
+| Name  | Type               |
+| :---- | :----------------- |
+| `req` | `express.Request`  |
 | `res` | `express.Response` |
 
 ##### Returns
@@ -59,23 +61,31 @@ pubsub-http-handler
 
 #### Defined in
 
-[methods/cloud-functions.ts:12](https://github.com/cobraz/pubsub-http-handler/blob/d14dfe1/src/methods/cloud-functions.ts#L12)
+[src/methods/cloud-functions.ts:12](https://github.com/cobraz/pubsub-http-handler/blob/f2a1dfc/src/methods/cloud-functions.ts#L12)
 
-___
+---
 
 ### OnErrorHandler
 
-Ƭ **OnErrorHandler**: (`error`: `unknown`) => `void` \| `Promise`<`void`\>
+Ƭ **OnErrorHandler**<`Context`\>: (`error`: `unknown`, `context`: `Context`) =>
+`void` \| `Promise`<`void`\>
+
+#### Type parameters
+
+| Name      |
+| :-------- |
+| `Context` |
 
 #### Type declaration
 
-▸ (`error`): `void` \| `Promise`<`void`\>
+▸ (`error`, `context`): `void` \| `Promise`<`void`\>
 
 ##### Parameters
 
-| Name | Type |
-| :------ | :------ |
-| `error` | `unknown` |
+| Name      | Type      |
+| :-------- | :-------- |
+| `error`   | `unknown` |
+| `context` | `Context` |
 
 ##### Returns
 
@@ -83,100 +93,120 @@ ___
 
 #### Defined in
 
-[types.ts:56](https://github.com/cobraz/pubsub-http-handler/blob/d14dfe1/src/types.ts#L56)
+[src/types.ts:60](https://github.com/cobraz/pubsub-http-handler/blob/f2a1dfc/src/types.ts#L60)
 
-___
+---
 
 ### PubSubHandler
 
-Ƭ **PubSubHandler**<`T`\>: (`args`: { `context?`: `unknown` ; `data?`: `T` ; `log`: `FastifyLoggerInstance` ; `message`: [`PubSubMessageType`](README.md#pubsubmessagetype)  }) => `Promise`<[`PubSubHandlerResponse`](classes/PubSubHandlerResponse.md) \| `void`\> \| [`PubSubHandlerResponse`](classes/PubSubHandlerResponse.md) \| `void`
+Ƭ **PubSubHandler**<`Data`, `Context`\>: (`args`: { `context?`: `Context` ;
+`data`: `Data` ; `log`: `FastifyBaseLogger` ; `message`:
+[`PubSubMessageType`](README.md#pubsubmessagetype) }) =>
+`Promise`<[`PubSubHandlerResponse`](classes/PubSubHandlerResponse.md) \|
+`void`\> \| [`PubSubHandlerResponse`](classes/PubSubHandlerResponse.md) \|
+`void`
 
 #### Type parameters
 
-| Name | Type |
-| :------ | :------ |
-| `T` | `any` |
+| Name      |
+| :-------- |
+| `Data`    |
+| `Context` |
 
 #### Type declaration
 
-▸ (`args`): `Promise`<[`PubSubHandlerResponse`](classes/PubSubHandlerResponse.md) \| `void`\> \| [`PubSubHandlerResponse`](classes/PubSubHandlerResponse.md) \| `void`
+▸ (`args`):
+`Promise`<[`PubSubHandlerResponse`](classes/PubSubHandlerResponse.md) \|
+`void`\> \| [`PubSubHandlerResponse`](classes/PubSubHandlerResponse.md) \|
+`void`
 
 ##### Parameters
 
-| Name | Type |
-| :------ | :------ |
-| `args` | `Object` |
-| `args.context?` | `unknown` |
-| `args.data?` | `T` |
-| `args.log` | `FastifyLoggerInstance` |
-| `args.message` | [`PubSubMessageType`](README.md#pubsubmessagetype) |
+| Name            | Type                                               |
+| :-------------- | :------------------------------------------------- |
+| `args`          | `Object`                                           |
+| `args.context?` | `Context`                                          |
+| `args.data`     | `Data`                                             |
+| `args.log`      | `FastifyBaseLogger`                                |
+| `args.message`  | [`PubSubMessageType`](README.md#pubsubmessagetype) |
 
 ##### Returns
 
-`Promise`<[`PubSubHandlerResponse`](classes/PubSubHandlerResponse.md) \| `void`\> \| [`PubSubHandlerResponse`](classes/PubSubHandlerResponse.md) \| `void`
+`Promise`<[`PubSubHandlerResponse`](classes/PubSubHandlerResponse.md) \|
+`void`\> \| [`PubSubHandlerResponse`](classes/PubSubHandlerResponse.md) \|
+`void`
 
 #### Defined in
 
-[types.ts:49](https://github.com/cobraz/pubsub-http-handler/blob/d14dfe1/src/types.ts#L49)
+[src/types.ts:53](https://github.com/cobraz/pubsub-http-handler/blob/f2a1dfc/src/types.ts#L53)
 
-___
+---
 
 ### PubSubMessageType
 
-Ƭ **PubSubMessageType**: `Static`<typeof [`PubSubMessage`](README.md#pubsubmessage)\>
+Ƭ **PubSubMessageType**: `Static`<typeof
+[`PubSubMessage`](README.md#pubsubmessage)\>
 
 #### Defined in
 
-[types.ts:36](https://github.com/cobraz/pubsub-http-handler/blob/d14dfe1/src/types.ts#L36)
+[src/types.ts:40](https://github.com/cobraz/pubsub-http-handler/blob/f2a1dfc/src/types.ts#L40)
 
-___
+---
 
 ### PubSubRequestType
 
-Ƭ **PubSubRequestType**: `Static`<typeof [`PubSubRequest`](README.md#pubsubrequest)\>
+Ƭ **PubSubRequestType**: `Static`<typeof
+[`PubSubRequest`](README.md#pubsubrequest)\>
 
 #### Defined in
 
-[types.ts:43](https://github.com/cobraz/pubsub-http-handler/blob/d14dfe1/src/types.ts#L43)
+[src/types.ts:47](https://github.com/cobraz/pubsub-http-handler/blob/f2a1dfc/src/types.ts#L47)
 
 ## Variables
 
 ### PubSubMessage
 
-• `Const` **PubSubMessage**: `TObject`<{ `attributes`: `TOptional`<`TRecord`<`TString`, `TString`\>\> ; `data`: `TString` ; `messageId`: `TOptional`<`TString`\>  }\>
+• `Const` **PubSubMessage**: `TObject`<{ `attributes`:
+`TOptional`<`TRecord`<`TString`, `TString`\>\> ; `data`: `TString` ;
+`messageId`: `TOptional`<`TString`\> }\>
 
 #### Defined in
 
-[types.ts:30](https://github.com/cobraz/pubsub-http-handler/blob/d14dfe1/src/types.ts#L30)
+[src/types.ts:34](https://github.com/cobraz/pubsub-http-handler/blob/f2a1dfc/src/types.ts#L34)
 
-___
+---
 
 ### PubSubRequest
 
-• `Const` **PubSubRequest**: `TObject`<{ `message`: `TObject`<{ `attributes`: `TOptional`<`TRecord`<`TString`, `TString`\>\> ; `data`: `TString` ; `messageId`: `TOptional`<`TString`\>  }\> = PubSubMessage; `subscription`: `TString`  }\>
+• `Const` **PubSubRequest**: `TObject`<{ `message`: `TObject`<{ `attributes`:
+`TOptional`<`TRecord`<`TString`, `TString`\>\> ; `data`: `TString` ;
+`messageId`: `TOptional`<`TString`\> }\> = PubSubMessage; `subscription`:
+`TString` }\>
 
 #### Defined in
 
-[types.ts:38](https://github.com/cobraz/pubsub-http-handler/blob/d14dfe1/src/types.ts#L38)
+[src/types.ts:42](https://github.com/cobraz/pubsub-http-handler/blob/f2a1dfc/src/types.ts#L42)
 
 ## Functions
 
 ### createPubSubCloudFunctions
 
-▸ **createPubSubCloudFunctions**<`T`\>(`handler`, `options?`): [`CloudFunctionFun`](README.md#cloudfunctionfun)
+▸ **createPubSubCloudFunctions**<`Data`, `Context`\>(`handler`, `options?`):
+[`CloudFunctionFun`](README.md#cloudfunctionfun)
 
 #### Type parameters
 
-| Name | Type |
-| :------ | :------ |
-| `T` | `unknown` |
+| Name      | Type      |
+| :-------- | :-------- |
+| `Data`    | `unknown` |
+| `Context` | `unknown` |
 
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
-| `handler` | [`PubSubHandler`](README.md#pubsubhandler)<`T`\> |
-| `options` | [`PubSubCloudFunctionsConfig`](interfaces/PubSubCloudFunctionsConfig.md) |
+| Name      | Type                                                                                         |
+| :-------- | :------------------------------------------------------------------------------------------- |
+| `handler` | [`PubSubHandler`](README.md#pubsubhandler)<`Data`, `Context`\>                               |
+| `options` | [`PubSubCloudFunctionsConfig`](interfaces/PubSubCloudFunctionsConfig.md)<`Data`, `Context`\> |
 
 #### Returns
 
@@ -184,26 +214,27 @@ ___
 
 #### Defined in
 
-[methods/cloud-functions.ts:17](https://github.com/cobraz/pubsub-http-handler/blob/d14dfe1/src/methods/cloud-functions.ts#L17)
+[src/methods/cloud-functions.ts:17](https://github.com/cobraz/pubsub-http-handler/blob/f2a1dfc/src/methods/cloud-functions.ts#L17)
 
-___
+---
 
 ### createPubSubServer
 
-▸ **createPubSubServer**<`T`\>(`handler`, `config?`): [`CreatePubSubHandlerResponse`](interfaces/CreatePubSubHandlerResponse.md)
+▸ **createPubSubServer**<`Data`\>(`handler`, `config?`):
+[`CreatePubSubHandlerResponse`](interfaces/CreatePubSubHandlerResponse.md)
 
 #### Type parameters
 
-| Name | Type |
-| :------ | :------ |
-| `T` | `unknown` |
+| Name   |
+| :----- |
+| `Data` |
 
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
-| `handler` | [`PubSubHandler`](README.md#pubsubhandler)<`T`\> |
-| `config` | [`PubSubServerConfig`](interfaces/PubSubServerConfig.md) |
+| Name      | Type                                                                                                                                                                                                                                                                                                                            |
+| :-------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `handler` | [`PubSubHandler`](README.md#pubsubhandler)<`Data`, `FastifyRequest`<`RouteGenericInterface`, `Server`, `IncomingMessage`, `FastifySchema`, `FastifyTypeProviderDefault`, `unknown`, `FastifyBaseLogger`, `ResolveFastifyRequestType`<`FastifyTypeProviderDefault`, `FastifySchema`, `RouteGenericInterface`\>\>\>               |
+| `config`  | [`PubSubServerConfig`](interfaces/PubSubServerConfig.md)<`Data`, `FastifyRequest`<`RouteGenericInterface`, `Server`, `IncomingMessage`, `FastifySchema`, `FastifyTypeProviderDefault`, `unknown`, `FastifyBaseLogger`, `ResolveFastifyRequestType`<`FastifyTypeProviderDefault`, `FastifySchema`, `RouteGenericInterface`\>\>\> |
 
 #### Returns
 
@@ -211,46 +242,90 @@ ___
 
 #### Defined in
 
-[methods/server.ts:35](https://github.com/cobraz/pubsub-http-handler/blob/d14dfe1/src/methods/server.ts#L35)
+[src/methods/server.ts:39](https://github.com/cobraz/pubsub-http-handler/blob/f2a1dfc/src/methods/server.ts#L39)
 
-___
+---
 
 ### handlePubSubMessage
 
-▸ **handlePubSubMessage**<`Context`\>(`args`): `Promise`<[`PubSubHandlerResponse`](classes/PubSubHandlerResponse.md) \| `void`\>
+▸ **handlePubSubMessage**<`Data`, `Context`\>(`args`):
+`Promise`<[`PubSubHandlerResponse`](classes/PubSubHandlerResponse.md) \|
+`void`\>
 
 #### Type parameters
 
-| Name | Type |
-| :------ | :------ |
-| `Context` | `unknown` |
+| Name      |
+| :-------- |
+| `Data`    |
+| `Context` |
 
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
-| `args` | [`HandlePubSubMessageArgs`](interfaces/HandlePubSubMessageArgs.md)<`Context`\> |
+| Name   | Type                                                                                   |
+| :----- | :------------------------------------------------------------------------------------- |
+| `args` | [`HandlePubSubMessageArgs`](interfaces/HandlePubSubMessageArgs.md)<`Data`, `Context`\> |
 
 #### Returns
 
-`Promise`<[`PubSubHandlerResponse`](classes/PubSubHandlerResponse.md) \| `void`\>
+`Promise`<[`PubSubHandlerResponse`](classes/PubSubHandlerResponse.md) \|
+`void`\>
 
 #### Defined in
 
-[common.ts:16](https://github.com/cobraz/pubsub-http-handler/blob/d14dfe1/src/common.ts#L16)
+[src/common.ts:5](https://github.com/cobraz/pubsub-http-handler/blob/f2a1dfc/src/common.ts#L5)
 
-___
+---
 
-### pubSubFastifyPlugin
+### makePubSubConfig
 
-▸ **pubSubFastifyPlugin**(`instance`, `opts`): `Promise`<`void`\>
+▸ **makePubSubConfig**<`Data`, `Context`\>(`data`):
+[`PubSubConfig`](interfaces/PubSubConfig.md)<`Data`, `Context`\>
+
+#### Type parameters
+
+| Name      |
+| :-------- |
+| `Data`    |
+| `Context` |
 
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
-| `instance` | `FastifyInstance`<`Server`, `IncomingMessage`, `ServerResponse`, `FastifyLoggerInstance`, `FastifyTypeProviderDefault`\> |
-| `opts` | [`PubSubConfig`](interfaces/PubSubConfig.md) |
+| Name   | Type                                                             |
+| :----- | :--------------------------------------------------------------- |
+| `data` | [`PubSubConfig`](interfaces/PubSubConfig.md)<`Data`, `Context`\> |
+
+#### Returns
+
+[`PubSubConfig`](interfaces/PubSubConfig.md)<`Data`, `Context`\>
+
+#### Defined in
+
+[src/utils.ts:3](https://github.com/cobraz/pubsub-http-handler/blob/f2a1dfc/src/utils.ts#L3)
+
+---
+
+### pubSubFastifyPlugin
+
+▸ **pubSubFastifyPlugin**<`Data`\>(`instance`, `opts`): `Promise`<`void`\>
+
+FastifyPluginAsync
+
+Fastify allows the user to extend its functionalities with plugins. A plugin can
+be a set of routes, a server decorator or whatever. To activate plugins, use the
+`fastify.register()` method.
+
+#### Type parameters
+
+| Name   | Type      |
+| :----- | :-------- |
+| `Data` | `unknown` |
+
+#### Parameters
+
+| Name       | Type                                                                                                                                                                                                                                                                                                                |
+| :--------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `instance` | `FastifyInstance`<`Server`, `IncomingMessage`, `ServerResponse`, `FastifyBaseLogger`, `FastifyTypeProviderDefault`\>                                                                                                                                                                                                |
+| `opts`     | [`PubSubConfig`](interfaces/PubSubConfig.md)<`Data`, `FastifyRequest`<`RouteGenericInterface`, `Server`, `IncomingMessage`, `FastifySchema`, `FastifyTypeProviderDefault`, `unknown`, `FastifyBaseLogger`, `ResolveFastifyRequestType`<`FastifyTypeProviderDefault`, `FastifySchema`, `RouteGenericInterface`\>\>\> |
 
 #### Returns
 
@@ -258,4 +333,4 @@ ___
 
 #### Defined in
 
-[methods/fastify-plugin.ts:5](https://github.com/cobraz/pubsub-http-handler/blob/d14dfe1/src/methods/fastify-plugin.ts#L5)
+node_modules/fastify/types/plugin.d.ts:28

--- a/docs/classes/pubsubhandlerresponse.md
+++ b/docs/classes/pubsubhandlerresponse.md
@@ -26,4 +26,4 @@
 
 #### Defined in
 
-[types.ts:46](https://github.com/cobraz/pubsub-http-handler/blob/d14dfe1/src/types.ts#L46)
+[src/types.ts:50](https://github.com/cobraz/pubsub-http-handler/blob/f2a1dfc/src/types.ts#L50)

--- a/docs/interfaces/PubSubCloudFunctionsConfig.md
+++ b/docs/interfaces/PubSubCloudFunctionsConfig.md
@@ -1,10 +1,18 @@
 [pubsub-http-handler](../README.md) / PubSubCloudFunctionsConfig
 
-# Interface: PubSubCloudFunctionsConfig
+# Interface: PubSubCloudFunctionsConfig<Data, Context\>
+
+## Type parameters
+
+| Name      |
+| :-------- |
+| `Data`    |
+| `Context` |
 
 ## Hierarchy
 
-- `Omit`<[`PubSubConfig`](PubSubConfig.md), ``"handler"`` \| ``"path"``\>
+- `Omit`<[`PubSubConfig`](PubSubConfig.md)<`Data`, `Context`\>, `"handler"` \|
+  `"path"`\>
 
   ↳ **`PubSubCloudFunctionsConfig`**
 
@@ -15,6 +23,7 @@
 - [logger](PubSubCloudFunctionsConfig.md#logger)
 - [onError](PubSubCloudFunctionsConfig.md#onerror)
 - [parseJson](PubSubCloudFunctionsConfig.md#parsejson)
+- [parser](PubSubCloudFunctionsConfig.md#parser)
 
 ## Properties
 
@@ -24,18 +33,18 @@
 
 #### Defined in
 
-[methods/cloud-functions.ts:9](https://github.com/cobraz/pubsub-http-handler/blob/d14dfe1/src/methods/cloud-functions.ts#L9)
+[src/methods/cloud-functions.ts:9](https://github.com/cobraz/pubsub-http-handler/blob/f2a1dfc/src/methods/cloud-functions.ts#L9)
 
-___
+---
 
 ### onError
 
-• `Optional` **onError**: [`OnErrorHandler`](../README.md#onerrorhandler)
+• `Optional` **onError**:
+[`OnErrorHandler`](../README.md#onerrorhandler)<`Context`\>
 
 OnError Handler
 
-When this is set, errors will not be
-thrown.
+When this is set, errors will not be thrown.
 
 #### Inherited from
 
@@ -43,9 +52,9 @@ Omit.onError
 
 #### Defined in
 
-[types.ts:15](https://github.com/cobraz/pubsub-http-handler/blob/d14dfe1/src/types.ts#L15)
+[src/types.ts:16](https://github.com/cobraz/pubsub-http-handler/blob/f2a1dfc/src/types.ts#L16)
 
-___
+---
 
 ### parseJson
 
@@ -55,7 +64,9 @@ This will run JSON.parse on request data
 
 **Tip**: `false` when sending strings
 
-**`default`** true
+**`Default`**
+
+true
 
 #### Inherited from
 
@@ -63,4 +74,32 @@ Omit.parseJson
 
 #### Defined in
 
-[types.ts:22](https://github.com/cobraz/pubsub-http-handler/blob/d14dfe1/src/types.ts#L22)
+[src/types.ts:25](https://github.com/cobraz/pubsub-http-handler/blob/f2a1dfc/src/types.ts#L25)
+
+---
+
+### parser
+
+• `Optional` **parser**: (`data`: `unknown`) => `Data` \| `Promise`<`Data`\>
+
+#### Type declaration
+
+▸ (`data`): `Data` \| `Promise`<`Data`\>
+
+##### Parameters
+
+| Name   | Type      |
+| :----- | :-------- |
+| `data` | `unknown` |
+
+##### Returns
+
+`Data` \| `Promise`<`Data`\>
+
+#### Inherited from
+
+Omit.parser
+
+#### Defined in
+
+[src/types.ts:18](https://github.com/cobraz/pubsub-http-handler/blob/f2a1dfc/src/types.ts#L18)

--- a/docs/interfaces/createpubsubhandlerresponse.md
+++ b/docs/interfaces/createpubsubhandlerresponse.md
@@ -7,31 +7,33 @@
 ### Properties
 
 - [fastify](CreatePubSubHandlerResponse.md#fastify)
-
-### Methods
-
 - [listen](CreatePubSubHandlerResponse.md#listen)
 
 ## Properties
 
 ### fastify
 
-• **fastify**: `FastifyInstance`<`Server`, `IncomingMessage`, `ServerResponse`, `FastifyLoggerInstance`, `FastifyTypeProviderDefault`\>
+• **fastify**: `FastifyInstance`<`Server`, `IncomingMessage`, `ServerResponse`,
+`FastifyBaseLogger`, `FastifyTypeProviderDefault`\>
 
 #### Defined in
 
-[methods/server.ts:32](https://github.com/cobraz/pubsub-http-handler/blob/d14dfe1/src/methods/server.ts#L32)
+[src/methods/server.ts:36](https://github.com/cobraz/pubsub-http-handler/blob/f2a1dfc/src/methods/server.ts#L36)
 
-## Methods
+---
 
 ### listen
 
-▸ **listen**(): `Promise`<`void`\>
+• **listen**: () => `Promise`<`void`\>
 
-#### Returns
+#### Type declaration
+
+▸ (): `Promise`<`void`\>
+
+##### Returns
 
 `Promise`<`void`\>
 
 #### Defined in
 
-[methods/server.ts:31](https://github.com/cobraz/pubsub-http-handler/blob/d14dfe1/src/methods/server.ts#L31)
+[src/methods/server.ts:35](https://github.com/cobraz/pubsub-http-handler/blob/f2a1dfc/src/methods/server.ts#L35)

--- a/docs/interfaces/handlepubsubmessageargs.md
+++ b/docs/interfaces/handlepubsubmessageargs.md
@@ -1,12 +1,13 @@
 [pubsub-http-handler](../README.md) / HandlePubSubMessageArgs
 
-# Interface: HandlePubSubMessageArgs<Context\>
+# Interface: HandlePubSubMessageArgs<Data, Context\>
 
 ## Type parameters
 
-| Name | Type |
-| :------ | :------ |
-| `Context` | `unknown` |
+| Name      |
+| :-------- |
+| `Data`    |
+| `Context` |
 
 ## Table of contents
 
@@ -17,38 +18,39 @@
 - [log](HandlePubSubMessageArgs.md#log)
 - [message](HandlePubSubMessageArgs.md#message)
 - [parseJson](HandlePubSubMessageArgs.md#parsejson)
+- [parser](HandlePubSubMessageArgs.md#parser)
 
 ## Properties
 
 ### context
 
-• `Optional` **context**: `Context`
+• **context**: `Context`
 
 #### Defined in
 
-[common.ts:12](https://github.com/cobraz/pubsub-http-handler/blob/d14dfe1/src/common.ts#L12)
+[src/types.ts:70](https://github.com/cobraz/pubsub-http-handler/blob/f2a1dfc/src/types.ts#L70)
 
-___
+---
 
 ### handler
 
-• **handler**: [`PubSubHandler`](../README.md#pubsubhandler)<`any`\>
+• **handler**: [`PubSubHandler`](../README.md#pubsubhandler)<`Data`, `Context`\>
 
 #### Defined in
 
-[common.ts:10](https://github.com/cobraz/pubsub-http-handler/blob/d14dfe1/src/common.ts#L10)
+[src/types.ts:67](https://github.com/cobraz/pubsub-http-handler/blob/f2a1dfc/src/types.ts#L67)
 
-___
+---
 
 ### log
 
-• **log**: `Logger`<`LoggerOptions`\>
+• `Optional` **log**: `FastifyBaseLogger` \| `Logger`<`LoggerOptions`\>
 
 #### Defined in
 
-[common.ts:13](https://github.com/cobraz/pubsub-http-handler/blob/d14dfe1/src/common.ts#L13)
+[src/types.ts:71](https://github.com/cobraz/pubsub-http-handler/blob/f2a1dfc/src/types.ts#L71)
 
-___
+---
 
 ### message
 
@@ -56,17 +58,17 @@ ___
 
 #### Type declaration
 
-| Name | Type |
-| :------ | :------ |
+| Name         | Type                                         |
+| :----------- | :------------------------------------------- |
 | `attributes` | `undefined` \| `Record`<`string`, `string`\> |
-| `data` | `string` |
-| `messageId` | `undefined` \| `string` |
+| `data`       | `string`                                     |
+| `messageId`  | `undefined` \| `string`                      |
 
 #### Defined in
 
-[common.ts:9](https://github.com/cobraz/pubsub-http-handler/blob/d14dfe1/src/common.ts#L9)
+[src/types.ts:66](https://github.com/cobraz/pubsub-http-handler/blob/f2a1dfc/src/types.ts#L66)
 
-___
+---
 
 ### parseJson
 
@@ -74,4 +76,28 @@ ___
 
 #### Defined in
 
-[common.ts:11](https://github.com/cobraz/pubsub-http-handler/blob/d14dfe1/src/common.ts#L11)
+[src/types.ts:68](https://github.com/cobraz/pubsub-http-handler/blob/f2a1dfc/src/types.ts#L68)
+
+---
+
+### parser
+
+• `Optional` **parser**: (`data`: `unknown`) => `Data` \| `Promise`<`Data`\>
+
+#### Type declaration
+
+▸ (`data`): `Data` \| `Promise`<`Data`\>
+
+##### Parameters
+
+| Name   | Type      |
+| :----- | :-------- |
+| `data` | `unknown` |
+
+##### Returns
+
+`Data` \| `Promise`<`Data`\>
+
+#### Defined in
+
+[src/types.ts:69](https://github.com/cobraz/pubsub-http-handler/blob/f2a1dfc/src/types.ts#L69)

--- a/docs/interfaces/pubsubconfig.md
+++ b/docs/interfaces/pubsubconfig.md
@@ -1,6 +1,13 @@
 [pubsub-http-handler](../README.md) / PubSubConfig
 
-# Interface: PubSubConfig
+# Interface: PubSubConfig<Data, Context\>
+
+## Type parameters
+
+| Name      |
+| :-------- |
+| `Data`    |
+| `Context` |
 
 ## Table of contents
 
@@ -9,36 +16,37 @@
 - [handler](PubSubConfig.md#handler)
 - [onError](PubSubConfig.md#onerror)
 - [parseJson](PubSubConfig.md#parsejson)
+- [parser](PubSubConfig.md#parser)
 - [path](PubSubConfig.md#path)
 
 ## Properties
 
 ### handler
 
-• **handler**: [`PubSubHandler`](../README.md#pubsubhandler)<`any`\>
+• **handler**: [`PubSubHandler`](../README.md#pubsubhandler)<`Data`, `Context`\>
 
 Handler
 
 #### Defined in
 
-[types.ts:8](https://github.com/cobraz/pubsub-http-handler/blob/d14dfe1/src/types.ts#L8)
+[src/types.ts:9](https://github.com/cobraz/pubsub-http-handler/blob/f2a1dfc/src/types.ts#L9)
 
-___
+---
 
 ### onError
 
-• `Optional` **onError**: [`OnErrorHandler`](../README.md#onerrorhandler)
+• `Optional` **onError**:
+[`OnErrorHandler`](../README.md#onerrorhandler)<`Context`\>
 
 OnError Handler
 
-When this is set, errors will not be
-thrown.
+When this is set, errors will not be thrown.
 
 #### Defined in
 
-[types.ts:15](https://github.com/cobraz/pubsub-http-handler/blob/d14dfe1/src/types.ts#L15)
+[src/types.ts:16](https://github.com/cobraz/pubsub-http-handler/blob/f2a1dfc/src/types.ts#L16)
 
-___
+---
 
 ### parseJson
 
@@ -48,13 +56,39 @@ This will run JSON.parse on request data
 
 **Tip**: `false` when sending strings
 
-**`default`** true
+**`Default`**
+
+true
 
 #### Defined in
 
-[types.ts:22](https://github.com/cobraz/pubsub-http-handler/blob/d14dfe1/src/types.ts#L22)
+[src/types.ts:25](https://github.com/cobraz/pubsub-http-handler/blob/f2a1dfc/src/types.ts#L25)
 
-___
+---
+
+### parser
+
+• `Optional` **parser**: (`data`: `unknown`) => `Data` \| `Promise`<`Data`\>
+
+#### Type declaration
+
+▸ (`data`): `Data` \| `Promise`<`Data`\>
+
+##### Parameters
+
+| Name   | Type      |
+| :----- | :-------- |
+| `data` | `unknown` |
+
+##### Returns
+
+`Data` \| `Promise`<`Data`\>
+
+#### Defined in
+
+[src/types.ts:18](https://github.com/cobraz/pubsub-http-handler/blob/f2a1dfc/src/types.ts#L18)
+
+---
 
 ### path
 
@@ -62,8 +96,10 @@ ___
 
 Use this to set a different path
 
-**`default`** /
+**`Default`**
+
+/
 
 #### Defined in
 
-[types.ts:27](https://github.com/cobraz/pubsub-http-handler/blob/d14dfe1/src/types.ts#L27)
+[src/types.ts:31](https://github.com/cobraz/pubsub-http-handler/blob/f2a1dfc/src/types.ts#L31)

--- a/docs/interfaces/pubsubserverconfig.md
+++ b/docs/interfaces/pubsubserverconfig.md
@@ -1,10 +1,17 @@
 [pubsub-http-handler](../README.md) / PubSubServerConfig
 
-# Interface: PubSubServerConfig
+# Interface: PubSubServerConfig<Data, Context\>
+
+## Type parameters
+
+| Name      |
+| :-------- |
+| `Data`    |
+| `Context` |
 
 ## Hierarchy
 
-- `Omit`<[`PubSubConfig`](PubSubConfig.md), ``"handler"``\>
+- `Omit`<[`PubSubConfig`](PubSubConfig.md)<`Data`, `Context`\>, `"handler"`\>
 
   ↳ **`PubSubServerConfig`**
 
@@ -17,6 +24,7 @@
 - [host](PubSubServerConfig.md#host)
 - [onError](PubSubServerConfig.md#onerror)
 - [parseJson](PubSubServerConfig.md#parsejson)
+- [parser](PubSubServerConfig.md#parser)
 - [path](PubSubServerConfig.md#path)
 - [port](PubSubServerConfig.md#port)
 
@@ -26,48 +34,55 @@
 
 • `Optional` **address**: `string`
 
-**`default`** 0.0.0.0
+**`Default`**
 
-**`deprecated`** `address` will be removed in next major release. Please use `host` instead.
+0.0.0.0
+
+**`Deprecated`**
+
+`address` will be removed in next major release. Please use `host` instead.
 
 #### Defined in
 
-[methods/server.ts:22](https://github.com/cobraz/pubsub-http-handler/blob/d14dfe1/src/methods/server.ts#L22)
+[src/methods/server.ts:26](https://github.com/cobraz/pubsub-http-handler/blob/f2a1dfc/src/methods/server.ts#L26)
 
-___
+---
 
 ### fastifyConfig
 
-• `Optional` **fastifyConfig**: `FastifyServerOptions`<`Server`, `FastifyLoggerInstance`\>
+• `Optional` **fastifyConfig**: `FastifyServerOptions`<`Server`,
+`FastifyBaseLogger`\>
 
 Read more here: https://www.fastify.io/docs/latest/Server/
 
 #### Defined in
 
-[methods/server.ts:27](https://github.com/cobraz/pubsub-http-handler/blob/d14dfe1/src/methods/server.ts#L27)
+[src/methods/server.ts:31](https://github.com/cobraz/pubsub-http-handler/blob/f2a1dfc/src/methods/server.ts#L31)
 
-___
+---
 
 ### host
 
 • `Optional` **host**: `string`
 
-**`default`** 0.0.0.0
+**`Default`**
+
+0.0.0.0
 
 #### Defined in
 
-[methods/server.ts:16](https://github.com/cobraz/pubsub-http-handler/blob/d14dfe1/src/methods/server.ts#L16)
+[src/methods/server.ts:20](https://github.com/cobraz/pubsub-http-handler/blob/f2a1dfc/src/methods/server.ts#L20)
 
-___
+---
 
 ### onError
 
-• `Optional` **onError**: [`OnErrorHandler`](../README.md#onerrorhandler)
+• `Optional` **onError**:
+[`OnErrorHandler`](../README.md#onerrorhandler)<`Context`\>
 
 OnError Handler
 
-When this is set, errors will not be
-thrown.
+When this is set, errors will not be thrown.
 
 #### Inherited from
 
@@ -75,9 +90,9 @@ Omit.onError
 
 #### Defined in
 
-[types.ts:15](https://github.com/cobraz/pubsub-http-handler/blob/d14dfe1/src/types.ts#L15)
+[src/types.ts:16](https://github.com/cobraz/pubsub-http-handler/blob/f2a1dfc/src/types.ts#L16)
 
-___
+---
 
 ### parseJson
 
@@ -87,7 +102,9 @@ This will run JSON.parse on request data
 
 **Tip**: `false` when sending strings
 
-**`default`** true
+**`Default`**
+
+true
 
 #### Inherited from
 
@@ -95,9 +112,37 @@ Omit.parseJson
 
 #### Defined in
 
-[types.ts:22](https://github.com/cobraz/pubsub-http-handler/blob/d14dfe1/src/types.ts#L22)
+[src/types.ts:25](https://github.com/cobraz/pubsub-http-handler/blob/f2a1dfc/src/types.ts#L25)
 
-___
+---
+
+### parser
+
+• `Optional` **parser**: (`data`: `unknown`) => `Data` \| `Promise`<`Data`\>
+
+#### Type declaration
+
+▸ (`data`): `Data` \| `Promise`<`Data`\>
+
+##### Parameters
+
+| Name   | Type      |
+| :----- | :-------- |
+| `data` | `unknown` |
+
+##### Returns
+
+`Data` \| `Promise`<`Data`\>
+
+#### Inherited from
+
+Omit.parser
+
+#### Defined in
+
+[src/types.ts:18](https://github.com/cobraz/pubsub-http-handler/blob/f2a1dfc/src/types.ts#L18)
+
+---
 
 ### path
 
@@ -105,7 +150,9 @@ ___
 
 Use this to set a different path
 
-**`default`** /
+**`Default`**
+
+/
 
 #### Inherited from
 
@@ -113,9 +160,9 @@ Omit.path
 
 #### Defined in
 
-[types.ts:27](https://github.com/cobraz/pubsub-http-handler/blob/d14dfe1/src/types.ts#L27)
+[src/types.ts:31](https://github.com/cobraz/pubsub-http-handler/blob/f2a1dfc/src/types.ts#L31)
 
-___
+---
 
 ### port
 
@@ -123,8 +170,10 @@ ___
 
 Will automatically pick up PORT environment variable.
 
-**`default`** 8000
+**`Default`**
+
+8000
 
 #### Defined in
 
-[methods/server.ts:11](https://github.com/cobraz/pubsub-http-handler/blob/d14dfe1/src/methods/server.ts#L11)
+[src/methods/server.ts:15](https://github.com/cobraz/pubsub-http-handler/blob/f2a1dfc/src/methods/server.ts#L15)

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,5 @@
 import { Static, Type } from '@sinclair/typebox';
-import { FastifyBaseLogger, FastifyLoggerInstance } from 'fastify';
+import { FastifyBaseLogger } from 'fastify';
 import pino from 'pino';
 
 export interface PubSubConfig<Data, Context> {
@@ -54,7 +54,7 @@ export type PubSubHandler<Data, Context> = (args: {
   message: PubSubMessageType;
   data: Data;
   context?: Context;
-  log: FastifyLoggerInstance;
+  log: FastifyBaseLogger;
 }) => Promise<PubSubHandlerResponse | void> | PubSubHandlerResponse | void;
 
 export type OnErrorHandler<Context> = (


### PR DESCRIPTION
Removed usage of `FastifyLoggerInstance`, which is tagged as deprecated by fastify.

Also reran the docs-generation. Not sure if that should go in a separate PR? Looks like it hasn't been run for a while.