### PR TITLE
fix: Use handler return value as status in cloud functions

### DIFF
--- a/src/__tests__/cloud-functions.test.ts
+++ b/src/__tests__/cloud-functions.test.ts
@@ -24,7 +24,7 @@ describe('cloud functions', () => {
     };
     const onError = jest.fn();
     const send = jest.fn();
-    const fun = await createPubSubCloudFunctions(handle, { onError });
+    const fun = createPubSubCloudFunctions(handle, { onError });
     await fun(
       { body: payload } as any,
       { status: () => ({ send }) } as unknown as any,
@@ -39,11 +39,37 @@ describe('cloud functions', () => {
       throw new Error('error');
     };
     const send = jest.fn();
-    const fun = await createPubSubCloudFunctions(handle);
+    const fun = createPubSubCloudFunctions(handle);
 
     await fun(
       { body: payload } as any,
       { status: () => ({ send }) } as unknown as any,
     ).catch(e => expect(e.message).toBe('error'));
+  });
+
+  it('should return 200 by default', async () => {
+    const payload = createPubSubRequest('forward me');
+    const handle = () => {};
+    const send = jest.fn();
+    const statusFun = jest.fn(() => ({ send }));
+    const fun = createPubSubCloudFunctions(handle);
+
+    await fun({ body: payload } as any, { status: statusFun } as any);
+
+    expect(statusFun).toBeCalledTimes(1);
+    expect(statusFun).toHaveBeenCalledWith(200);
+  });
+
+  it('should return status code of handler', async () => {
+    const payload = createPubSubRequest('forward me');
+    const handle = () => ({ statusCode: 123 });
+    const send = jest.fn();
+    const statusFun = jest.fn(() => ({ send }));
+    const fun = createPubSubCloudFunctions(handle);
+
+    await fun({ body: payload } as any, { status: statusFun } as any);
+
+    expect(statusFun).toBeCalledTimes(1);
+    expect(statusFun).toHaveBeenCalledWith(123);
   });
 });

--- a/src/methods/cloud-functions.ts
+++ b/src/methods/cloud-functions.ts
@@ -22,7 +22,7 @@ export function createPubSubCloudFunctions<Data = unknown, Context = unknown>(
   return async (req, res): Promise<void> => {
     const context: Context = req.body;
     try {
-      await handlePubSubMessage({
+      const result = await handlePubSubMessage({
         message: req.body.message,
         handler,
         context,
@@ -30,7 +30,7 @@ export function createPubSubCloudFunctions<Data = unknown, Context = unknown>(
         log: pino(gcpLogOptions(logger)),
       });
 
-      res.status(200).send();
+      res.status(result?.statusCode ?? 200).send();
     } catch (error) {
       if (onError) {
         await onError(error, context);


### PR DESCRIPTION
We weren't actually using the return value from the handler in the cloud function implementation.
